### PR TITLE
Fix compilation with ICU 68

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -815,7 +815,7 @@ compile_graph( Compile *compile, ParseNode *pn, PElement *out )
 			break;
 
 		case PARSE_CONST_BOOL:
-			PEPUTP( out, ELEMENT_BOOL, pn->con.val.bool );
+			PEPUTP( out, ELEMENT_BOOL, pn->con.val.boolean );
 			break;
 
 		case PARSE_CONST_ELIST:
@@ -2523,7 +2523,7 @@ compile_pattern_condition( Compile *compile,
 	int i;
 
 	n.type = PARSE_CONST_BOOL;
-	n.val.bool = TRUE;
+	n.val.boolean = TRUE;
 	node = tree_const_new( compile, n );
 
 	for( i = depth - 1; i >= 0; i-- ) {

--- a/src/lex.l
+++ b/src/lex.l
@@ -207,7 +207,7 @@ TRUE {
 	BEGIN BINARY;
 
 	yylval.yy_const.type = PARSE_CONST_BOOL;
-	yylval.yy_const.val.bool = TRUE;
+	yylval.yy_const.val.boolean = TRUE;
 
 	return( TK_CONST );
 }
@@ -216,7 +216,7 @@ FALSE {
 	BEGIN BINARY;
 
 	yylval.yy_const.type = PARSE_CONST_BOOL;
-	yylval.yy_const.val.bool = FALSE;
+	yylval.yy_const.val.boolean = FALSE;
 
 	return( TK_CONST );
 }

--- a/src/tree.h
+++ b/src/tree.h
@@ -126,7 +126,7 @@ struct _ParseConst {
 	union {
 		double num;
 		char *str;
-		gboolean bool;
+		gboolean boolean;
 		int ch;
 	} val;
 };


### PR DESCRIPTION
Pretty simple, I tried to compile this on Arch Linux and couldn't because of recent changes to ICU. I fixed the issue:

nip2 depends on the ICU library via libxml2. ICU released version 68 on 2020-10-28, and switched to using the C99 bool type in its public headers. nip2 was using `bool` as the name for a gboolean in the ParseConst struct. This commit renames this to `boolean`.